### PR TITLE
.xcodeproj files: use relative build path

### DIFF
--- a/File_Extractor-1.0.0/libFileExtractor/libFileExtractor.xcodeproj/project.pbxproj
+++ b/File_Extractor-1.0.0/libFileExtractor/libFileExtractor.xcodeproj/project.pbxproj
@@ -638,7 +638,7 @@
 				PRODUCT_NAME = libFileExtractor;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 			};
 			name = Debug;
 		};
@@ -660,7 +660,7 @@
 				PRODUCT_NAME = libFileExtractor;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 			};
 			name = Release;
 		};
@@ -682,7 +682,7 @@
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -704,7 +704,7 @@
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/dumb/dumb.xcodeproj/project.pbxproj
+++ b/dumb/dumb.xcodeproj/project.pbxproj
@@ -631,7 +631,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = src/include;
 			};
@@ -654,7 +654,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.6;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = src/include;
 			};
@@ -678,7 +678,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -701,7 +701,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/libGME/libgme.xcodeproj/project.pbxproj
+++ b/libGME/libgme.xcodeproj/project.pbxproj
@@ -878,6 +878,7 @@
 				INSTALL_PATH = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				PRODUCT_NAME = libgme;
+				SYMROOT = build;
 			};
 			name = Debug;
 		};
@@ -901,6 +902,7 @@
 				INSTALL_PATH = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				PRODUCT_NAME = libgme;
+				SYMROOT = build;
 			};
 			name = Release;
 		};

--- a/libgsf/libgsf/libgsf.xcodeproj/project.pbxproj
+++ b/libgsf/libgsf/libgsf.xcodeproj/project.pbxproj
@@ -348,7 +348,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -368,7 +368,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -389,7 +389,7 @@
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -410,7 +410,7 @@
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/libmodplug/libmodplug.xcodeproj/project.pbxproj
+++ b/libmodplug/libmodplug.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				PRODUCT_NAME = libmodplug;
 				SDKROOT = iphoneos;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = dynamic;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -362,7 +362,7 @@
 				PRODUCT_NAME = libmodplug;
 				SDKROOT = iphoneos;
 				STANDARD_C_PLUS_PLUS_LIBRARY_TYPE = dynamic;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -390,7 +390,7 @@
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -418,7 +418,7 @@
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/libsidplay1/libsidplay1.xcodeproj/project.pbxproj
+++ b/libsidplay1/libsidplay1.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				PRODUCT_NAME = libsidplay1;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -360,7 +360,7 @@
 				PRODUCT_NAME = libsidplay1;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -382,7 +382,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -403,7 +403,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
 				SDKROOT = iphoneos;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/libsidplayfp-0.2.0/sidplayfp/sidplayfp.xcodeproj/project.pbxproj
+++ b/libsidplayfp-0.2.0/sidplayfp/sidplayfp.xcodeproj/project.pbxproj
@@ -836,7 +836,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				SDKROOT = iphoneos;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -855,7 +855,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
 				SDKROOT = iphoneos;
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -875,10 +875,10 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				INSTALL_PATH = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
-				OBJROOT = /Users/ymagnien/DevBuild;
+				OBJROOT = build;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -898,10 +898,10 @@
 				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				INSTALL_PATH = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.0;
-				OBJROOT = /Users/ymagnien/DevBuild;
+				OBJROOT = build;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYMROOT = /Users/ymagnien/DevBuild;
+				SYMROOT = build;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
I changed the Xcode project files to use relative path instead of fixed path; this makes it easier to share the project files with other developers. I tested and I was able to build Modizer after making these changes.
