### PR TITLE
Refactor dumb file loading code

### DIFF
--- a/modizer/Classes/ModizMusicPlayer.mm
+++ b/modizer/Classes/ModizMusicPlayer.mm
@@ -4893,71 +4893,33 @@ int uade_audio_play(char *pSound,int lBytes,int song_end) {
 		mod_minsub=1;
 		mod_maxsub=1;
 		mod_currentsub=1;
-		
+
         /* Load file */
-        dumbfile_open_memory(mp_data,mp_datasize);
-        duh = dumb_load_it([filePath UTF8String]);
-        if (!duh) {
+        typedef void (*func)(void);
+        typedef DUH *(*dumb1)(const char *);
+        typedef DUH *(*dumb2)(const char *, int);
+        func dumbFormats[15] = {
+        (func)&dumb_load_it, (func)&load_duh,
+        (func)&dumb_load_xm, (func)&dumb_load_s3m,
+        (func)&dumb_load_mod, (func)&dumb_load_stm,
+        (func)&dumb_load_ptm, (func)&dumb_load_669,
+        (func)&dumb_load_mtm, (func)&dumb_load_riff,
+        (func)&dumb_load_asy, (func)&dumb_load_amf,
+        (func)&dumb_load_okt, (func)&dumb_load_psm,
+        (func)&dumb_load_old_psm };
+
+        int i;
+        for(i = 0; i < 15; i++) {
             dumbfile_open_memory(mp_data,mp_datasize);
-            duh = load_duh([filePath UTF8String]);
-            if (!duh) {
-                dumbfile_open_memory(mp_data,mp_datasize);
-                duh = dumb_load_xm([filePath UTF8String]);
-                if (!duh) {
-                    dumbfile_open_memory(mp_data,mp_datasize);
-                    duh = dumb_load_s3m([filePath UTF8String]);
-                    if (!duh) {
-                        dumbfile_open_memory(mp_data,mp_datasize);
-                        duh = dumb_load_mod([filePath UTF8String],0);
-                        if (!duh) {
-                            dumbfile_open_memory(mp_data,mp_datasize);
-                            duh = dumb_load_stm([filePath UTF8String]);
-                            if (!duh) {
-                                dumbfile_open_memory(mp_data,mp_datasize);
-                                duh = dumb_load_ptm([filePath UTF8String]);
-                                if (!duh) {
-                                    dumbfile_open_memory(mp_data,mp_datasize);
-                                    duh = dumb_load_669([filePath UTF8String]);
-                                    if (!duh) {
-                                        dumbfile_open_memory(mp_data,mp_datasize);
-                                        duh = dumb_load_mtm([filePath UTF8String]);
-                                        if (!duh) {
-                                            dumbfile_open_memory(mp_data,mp_datasize);
-                                            duh = dumb_load_riff([filePath UTF8String]);
-                                            if (!duh) {
-                                                dumbfile_open_memory(mp_data,mp_datasize);
-                                                duh = dumb_load_asy([filePath UTF8String]);
-                                                if (!duh) {
-                                                    dumbfile_open_memory(mp_data,mp_datasize);
-                                                    duh = dumb_load_amf([filePath UTF8String]);
-                                                    if (!duh) {
-                                                        dumbfile_open_memory(mp_data,mp_datasize);
-                                                        duh = dumb_load_okt([filePath UTF8String]);
-                                                        if (!duh) {
-                                                            dumbfile_open_memory(mp_data,mp_datasize);
-                                                            duh = dumb_load_psm([filePath UTF8String],0);
-                                                            if (!duh) {
-                                                                dumbfile_open_memory(mp_data,mp_datasize);
-                                                                duh = dumb_load_old_psm([filePath UTF8String]);
-                                                                if (!duh) {
-                                                                    return 1;
-                                                                }
-                                                            } else {//got psm
-                                                                //mod_subsongs=dumb_get_psm_subsong_count(f);
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }                                                                                        
-                        }                                                            
-                    }
-                }
+            if(i==4||i==12) {
+                duh = ((dumb2)dumbFormats[i])([filePath UTF8String],0);
+            } else {
+                duh = ((dumb1)dumbFormats[i])([filePath UTF8String]);
             }
+            if(duh) {break;}
         }
+        if(!duh) {return 1;}
+
         iModuleLength = (int)((LONG_LONG)duh_get_length(duh) * 1000 >> 16);
         const char *mod_title = duh_get_tag(duh, "TITLE");
         if (mod_title && mod_title[0]) {


### PR DESCRIPTION
This commit replaces the set of nested if statements responsible for loading songs in dumb with a much more concise version. This doesn't change the behaviour at all - it just enhances readability.

I tested on a few songs (s3m, mod) and it works as normal. I didn't test every format dumb supports, but I don't think there should be a problem with the others.
