### PR TITLE
Skip silence detection for HES files

### DIFF
--- a/modizer/Classes/ModizMusicPlayer.mm
+++ b/modizer/Classes/ModizMusicPlayer.mm
@@ -3740,7 +3740,8 @@ int uade_audio_play(char *pSound,int lBytes,int song_end) {
 			gme_set_effects( gme_emu, &gme_fx);
 			
 			/**/
-			gme_ignore_silence(gme_emu,0);
+			int ignore_silence = strcmp(gmetype,"PC Engine") ? 1 : 0;
+			gme_ignore_silence(gme_emu,ignore_silence);
 			
 			track=0;
 			mod_subsongs=gme_track_count( gme_emu );


### PR DESCRIPTION
HES files have an issue with GME's silence detection - if the silence detection is hit, rather than the timeout, Modizer will end the file instead of skipping to the next subsong. To make HESs usable, this hack disables the silence timeout when HESs are detected.

Ideally the problem should be fixed wherever the file skipping on silence detection is occurring rather than doing something hackier like this, but I'm not sure where that's happening. Maybe you can fix that instead of merging this. ;)

This problem may not be exclusive to HES files.
