### PR TITLE
Correctly update flags when entering background

### DIFF
--- a/modizer/Classes/AppDelegate_Phone.mm
+++ b/modizer/Classes/AppDelegate_Phone.mm
@@ -243,6 +243,10 @@ pthread_mutex_t play_mutex;
 	//	[modizerWin becomeFirstResponder];
 	//	[[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
 	}
+
+    // Ensure that settings are saved if closed by OS after resigning active
+    [detailViewControlleriPhone saveSettings];
+	[detailViewControlleriPhone updateFlagOnExit];
 }
 
 // iOS 4 background support


### PR DESCRIPTION
This fixes #13.

Modizer was often reporting that it had crashed, and was asking to reset settings, in situations where it had not actually crashed.

If an app enters background while still remaining active, then resigns active status, it's eligible to be closed by the OS at any time without explicit notice to the inactive app. This was happening to Modizer if it was doing background playback of a song, and then the playlist ended or the user paused playback. Modizer didn't explicitly save its settings or mark that it had exited cleanly if this happened.

So, if the user then opened other apps, and the OS closed Modizer to reclaim RAM, Modizer would assume it had crashed the next time it opened.

This patch adds explicit calls to `saveSettings` and `updateFlagOnExit` if applicationWillResignActive is called to help guard against this. I've done some light testing, and it does look like it fixed the issue - which should fix something that was bugging me a lot. ;)
