### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/libs/libzxtune/libzxtune/3rdparty/lhasa/lib/lha_file_header.c
+++ b/libs/libzxtune/libzxtune/3rdparty/lhasa/lib/lha_file_header.c
@@ -277,6 +277,10 @@ static uint8_t *extend_raw_data(LHAFileHeader **header,
 	size_t new_raw_len;
 	uint8_t *result;
 
+	if (nbytes > LEVEL_3_MAX_HEADER_LEN) {
+		return NULL;
+	}
+
 	// Reallocate the header and raw_data area to be larger.
 
 	new_raw_len = RAW_DATA_LEN(header) + nbytes;
@@ -647,7 +651,8 @@ static int decode_level3_header(LHAFileHeader **header, LHAInputStream *stream)
 
 	header_len = lha_decode_uint32(&RAW_DATA(header, 24));
 
-	if (header_len > LEVEL_3_MAX_HEADER_LEN) {
+	if (header_len > LEVEL_3_MAX_HEADER_LEN
+	 || header_len < RAW_DATA_LEN(header)) {
 		return 0;
 	}
 


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `L3 decode` that was cloned from `fragglet/lhasa` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `L3 decode` in `libs/libzxtune/libzxtune/3rdparty/lhasa/lib/lha_file_header.c`
* **Original Fix**: https://github.com/fragglet/lhasa/commit/6fcdb8f1f538b9d63e63a5fa199c5514a15d4564

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/fragglet/lhasa/commit/6fcdb8f1f538b9d63e63a5fa199c5514a15d4564
* [CVE-2016-2347](https://nvd.nist.gov/vuln/detail/CVE-2016-2347)

Please review and merge this PR to ensure your repository is protected against this vulnerability.