### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/libs/libopenmpt/openmpt-trunk/include/premake/contrib/curl/lib/imap.c
+++ b/libs/libopenmpt/openmpt-trunk/include/premake/contrib/curl/lib/imap.c
@@ -1141,6 +1141,11 @@ static CURLcode imap_state_fetch_resp(struct connectdata *conn, int imapcode,
         /* The conversion from curl_off_t to size_t is always fine here */
         chunk = (size_t)size;
 
+      if(!chunk) {
+        /* no size, we're done with the data */
+        state(conn, IMAP_STOP);
+        return CURLE_OK;
+      }
       result = Curl_client_write(conn, CLIENTWRITE_BODY, pp->cache, chunk);
       if(result)
         return result;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `imap_state_fetch_resp` that was cloned from `curl/curl` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `imap_state_fetch_resp` in `libs/libopenmpt/openmpt-trunk/include/premake/contrib/curl/lib/imap.c`
* **Original Fix**: https://github.com/curl/curl/commit/13c9a9ded3ae744a1e11cbc14e9146d9fa427040

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/curl/curl/commit/13c9a9ded3ae744a1e11cbc14e9146d9fa427040
* [CVE-2017-1000257](https://nvd.nist.gov/vuln/detail/cve-2017-1000257)

Please review and merge this PR to ensure your repository is protected against this vulnerability.